### PR TITLE
Demo: Use external secondary storage

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,6 +15,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 16
         versionName '2.6.0'
+        applicationId 'exe.bbll8.aeolus'
     }
 
     buildFeatures {
@@ -50,12 +51,12 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
 
             if (useAnemoConfig) {
-                signingConfig = signingConfigs.named('anemo').get()
+                signingConfig = signingConfigs.named('exe.bbllw8.aeolus').get()
             }
         }
         debug {
             if (useAnemoConfig) {
-                signingConfig = signingConfigs.named('anemo').get()
+                signingConfig = signingConfigs.named('exe.bbllw8.aeolus').get()
             }
         }
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
   -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="exe.bbllw8.anemo">
+    package="exe.bbllw8.aeolus">
 
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
 
@@ -84,7 +84,7 @@
 
         <provider
             android:name=".documents.provider.AnemoDocumentProvider"
-            android:authorities="exe.bbllw8.anemo.documents"
+            android:authorities="exe.bbllw8.aeolus.documents"
             android:enabled="true"
             android:exported="true"
             android:grantUriPermissions="true"

--- a/app/src/main/java/exe/bbllw8/aeolus/config/ConfigurationActivity.java
+++ b/app/src/main/java/exe/bbllw8/aeolus/config/ConfigurationActivity.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2022 2bllw8
  * SPDX-License-Identifier: GPL-3.0-only
  */
-package exe.bbllw8.anemo.config;
+package exe.bbllw8.aeolus.config;
 
 import android.app.Activity;
 import android.content.Intent;
@@ -15,12 +15,12 @@ import androidx.annotation.Nullable;
 
 import java.util.function.Consumer;
 
-import exe.bbllw8.anemo.R;
-import exe.bbllw8.anemo.config.password.ChangePasswordDialog;
-import exe.bbllw8.anemo.config.password.SetPasswordDialog;
-import exe.bbllw8.anemo.lock.LockStore;
-import exe.bbllw8.anemo.lock.UnlockActivity;
-import exe.bbllw8.anemo.shell.AnemoShell;
+import exe.bbllw8.aeolus.R;
+import exe.bbllw8.aeolus.config.password.ChangePasswordDialog;
+import exe.bbllw8.aeolus.config.password.SetPasswordDialog;
+import exe.bbllw8.aeolus.lock.LockStore;
+import exe.bbllw8.aeolus.lock.UnlockActivity;
+import exe.bbllw8.aeolus.shell.AnemoShell;
 
 public final class ConfigurationActivity extends Activity {
 

--- a/app/src/main/java/exe/bbllw8/aeolus/config/password/ChangePasswordDialog.java
+++ b/app/src/main/java/exe/bbllw8/aeolus/config/password/ChangePasswordDialog.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2021 2bllw8
  * SPDX-License-Identifier: GPL-3.0-only
  */
-package exe.bbllw8.anemo.config.password;
+package exe.bbllw8.aeolus.config.password;
 
 import android.app.Activity;
 import android.content.DialogInterface;
@@ -10,40 +10,56 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 
-import exe.bbllw8.anemo.R;
-import exe.bbllw8.anemo.lock.LockStore;
+import exe.bbllw8.aeolus.R;
+import exe.bbllw8.aeolus.lock.LockStore;
 
-public final class SetPasswordDialog extends PasswordDialog {
+public final class ChangePasswordDialog extends PasswordDialog {
 
-    public SetPasswordDialog(Activity activity, LockStore lockStore, Runnable onSuccess) {
-        super(activity, lockStore, onSuccess, R.string.password_set_title,
-                R.layout.password_first_set);
+    public ChangePasswordDialog(Activity activity, LockStore lockStore, Runnable onSuccess) {
+        super(activity, lockStore, onSuccess, R.string.password_change_title,
+                R.layout.password_change);
     }
 
     @Override
     protected void build() {
+        final EditText currentField = dialog.findViewById(R.id.currentFieldView);
         final EditText passwordField = dialog.findViewById(R.id.passwordFieldView);
         final EditText repeatField = dialog.findViewById(R.id.repeatFieldView);
         final Button positiveBtn = dialog.getButton(DialogInterface.BUTTON_POSITIVE);
+        final Button neutralBtn = dialog.getButton(DialogInterface.BUTTON_NEUTRAL);
 
-        final TextListener validator = buildValidator(passwordField, repeatField, positiveBtn);
+        final TextListener validator = buildTextListener(passwordField, repeatField, positiveBtn);
         passwordField.addTextChangedListener(validator);
         repeatField.addTextChangedListener(validator);
 
         positiveBtn.setVisibility(View.VISIBLE);
-        positiveBtn.setText(R.string.password_set_action);
+        positiveBtn.setText(R.string.password_change_action);
         positiveBtn.setEnabled(false);
         positiveBtn.setOnClickListener(v -> {
-            final String passwordValue = passwordField.getText().toString();
-            if (lockStore.setPassword(passwordValue)) {
-                dismiss();
-                lockStore.unlock();
-                onSuccess.run();
+            final String currentPassword = currentField.getText().toString();
+            final String newPassword = passwordField.getText().toString();
+
+            if (lockStore.passwordMatch(currentPassword)) {
+                if (lockStore.setPassword(newPassword)) {
+                    dismiss();
+                    lockStore.unlock();
+                    onSuccess.run();
+                }
+            } else {
+                currentField.setError(res.getString(R.string.password_error_wrong), getErrorIcon());
             }
+        });
+
+        neutralBtn.setVisibility(View.VISIBLE);
+        neutralBtn.setText(R.string.password_change_remove);
+        neutralBtn.setOnClickListener(v -> {
+            lockStore.removePassword();
+            onSuccess.run();
+            dismiss();
         });
     }
 
-    private TextListener buildValidator(EditText passwordField, EditText repeatField,
+    private TextListener buildTextListener(EditText passwordField, EditText repeatField,
             Button positiveBtn) {
         return text -> {
             final String passwordValue = passwordField.getText().toString();

--- a/app/src/main/java/exe/bbllw8/aeolus/config/password/PasswordDialog.java
+++ b/app/src/main/java/exe/bbllw8/aeolus/config/password/PasswordDialog.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2021 2bllw8
  * SPDX-License-Identifier: GPL-3.0-only
  */
-package exe.bbllw8.anemo.config.password;
+package exe.bbllw8.aeolus.config.password;
 
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -12,8 +12,8 @@ import android.graphics.drawable.Drawable;
 import androidx.annotation.LayoutRes;
 import androidx.annotation.StringRes;
 
-import exe.bbllw8.anemo.R;
-import exe.bbllw8.anemo.lock.LockStore;
+import exe.bbllw8.aeolus.R;
+import exe.bbllw8.aeolus.lock.LockStore;
 
 public abstract class PasswordDialog {
     protected static final int MIN_PASSWORD_LENGTH = 4;

--- a/app/src/main/java/exe/bbllw8/aeolus/config/password/SetPasswordDialog.java
+++ b/app/src/main/java/exe/bbllw8/aeolus/config/password/SetPasswordDialog.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2021 2bllw8
  * SPDX-License-Identifier: GPL-3.0-only
  */
-package exe.bbllw8.anemo.config.password;
+package exe.bbllw8.aeolus.config.password;
 
 import android.app.Activity;
 import android.content.DialogInterface;
@@ -10,56 +10,40 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 
-import exe.bbllw8.anemo.R;
-import exe.bbllw8.anemo.lock.LockStore;
+import exe.bbllw8.aeolus.R;
+import exe.bbllw8.aeolus.lock.LockStore;
 
-public final class ChangePasswordDialog extends PasswordDialog {
+public final class SetPasswordDialog extends PasswordDialog {
 
-    public ChangePasswordDialog(Activity activity, LockStore lockStore, Runnable onSuccess) {
-        super(activity, lockStore, onSuccess, R.string.password_change_title,
-                R.layout.password_change);
+    public SetPasswordDialog(Activity activity, LockStore lockStore, Runnable onSuccess) {
+        super(activity, lockStore, onSuccess, R.string.password_set_title,
+                R.layout.password_first_set);
     }
 
     @Override
     protected void build() {
-        final EditText currentField = dialog.findViewById(R.id.currentFieldView);
         final EditText passwordField = dialog.findViewById(R.id.passwordFieldView);
         final EditText repeatField = dialog.findViewById(R.id.repeatFieldView);
         final Button positiveBtn = dialog.getButton(DialogInterface.BUTTON_POSITIVE);
-        final Button neutralBtn = dialog.getButton(DialogInterface.BUTTON_NEUTRAL);
 
-        final TextListener validator = buildTextListener(passwordField, repeatField, positiveBtn);
+        final TextListener validator = buildValidator(passwordField, repeatField, positiveBtn);
         passwordField.addTextChangedListener(validator);
         repeatField.addTextChangedListener(validator);
 
         positiveBtn.setVisibility(View.VISIBLE);
-        positiveBtn.setText(R.string.password_change_action);
+        positiveBtn.setText(R.string.password_set_action);
         positiveBtn.setEnabled(false);
         positiveBtn.setOnClickListener(v -> {
-            final String currentPassword = currentField.getText().toString();
-            final String newPassword = passwordField.getText().toString();
-
-            if (lockStore.passwordMatch(currentPassword)) {
-                if (lockStore.setPassword(newPassword)) {
-                    dismiss();
-                    lockStore.unlock();
-                    onSuccess.run();
-                }
-            } else {
-                currentField.setError(res.getString(R.string.password_error_wrong), getErrorIcon());
+            final String passwordValue = passwordField.getText().toString();
+            if (lockStore.setPassword(passwordValue)) {
+                dismiss();
+                lockStore.unlock();
+                onSuccess.run();
             }
-        });
-
-        neutralBtn.setVisibility(View.VISIBLE);
-        neutralBtn.setText(R.string.password_change_remove);
-        neutralBtn.setOnClickListener(v -> {
-            lockStore.removePassword();
-            onSuccess.run();
-            dismiss();
         });
     }
 
-    private TextListener buildTextListener(EditText passwordField, EditText repeatField,
+    private TextListener buildValidator(EditText passwordField, EditText repeatField,
             Button positiveBtn) {
         return text -> {
             final String passwordValue = passwordField.getText().toString();

--- a/app/src/main/java/exe/bbllw8/aeolus/config/password/TextListener.java
+++ b/app/src/main/java/exe/bbllw8/aeolus/config/password/TextListener.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2022 2bllw8
  * SPDX-License-Identifier: GPL-3.0-only
  */
-package exe.bbllw8.anemo.config.password;
+package exe.bbllw8.aeolus.config.password;
 
 import android.text.Editable;
 import android.text.TextWatcher;

--- a/app/src/main/java/exe/bbllw8/aeolus/documents/home/HomeEnvironment.java
+++ b/app/src/main/java/exe/bbllw8/aeolus/documents/home/HomeEnvironment.java
@@ -32,7 +32,7 @@ public final class HomeEnvironment {
     }
 
     private HomeEnvironment(Context context) throws IOException {
-        baseDir = context.getFilesDir().toPath().resolve(ROOT);
+        baseDir = context.getExternalFilesDirs(null)[1].toPath().resolve(ROOT);
         if (!Files.exists(baseDir)) {
             Files.createDirectory(baseDir);
         } else if (!Files.isDirectory(baseDir)) {

--- a/app/src/main/java/exe/bbllw8/aeolus/documents/home/HomeEnvironment.java
+++ b/app/src/main/java/exe/bbllw8/aeolus/documents/home/HomeEnvironment.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2021 2bllw8
  * SPDX-License-Identifier: GPL-3.0-only
  */
-package exe.bbllw8.anemo.documents.home;
+package exe.bbllw8.aeolus.documents.home;
 
 import android.content.Context;
 
@@ -11,9 +11,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 public final class HomeEnvironment {
-    public static final String AUTHORITY = "exe.bbllw8.anemo.documents";
+    public static final String AUTHORITY = "exe.bbllw8.aeolus.documents";
 
-    public static final String ROOT = "anemo";
+    public static final String ROOT = "aeolus";
     public static final String ROOT_DOC_ID = "root";
 
     private final Path baseDir;

--- a/app/src/main/java/exe/bbllw8/aeolus/documents/provider/AnemoDocumentProvider.java
+++ b/app/src/main/java/exe/bbllw8/aeolus/documents/provider/AnemoDocumentProvider.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2021 2bllw8
  * SPDX-License-Identifier: GPL-3.0-only
  */
-package exe.bbllw8.anemo.documents.provider;
+package exe.bbllw8.aeolus.documents.provider;
 
 import android.app.AuthenticationRequiredException;
 import android.app.PendingIntent;
@@ -28,10 +28,10 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.function.Consumer;
 
-import exe.bbllw8.anemo.R;
-import exe.bbllw8.anemo.documents.home.HomeEnvironment;
-import exe.bbllw8.anemo.lock.LockStore;
-import exe.bbllw8.anemo.lock.UnlockActivity;
+import exe.bbllw8.aeolus.R;
+import exe.bbllw8.aeolus.documents.home.HomeEnvironment;
+import exe.bbllw8.aeolus.lock.LockStore;
+import exe.bbllw8.aeolus.lock.UnlockActivity;
 import exe.bbllw8.either.Failure;
 import exe.bbllw8.either.Success;
 import exe.bbllw8.either.Try;

--- a/app/src/main/java/exe/bbllw8/aeolus/documents/provider/EmptyCursor.java
+++ b/app/src/main/java/exe/bbllw8/aeolus/documents/provider/EmptyCursor.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2022 2bllw8
  * SPDX-License-Identifier: GPL-3.0-only
  */
-package exe.bbllw8.anemo.documents.provider;
+package exe.bbllw8.aeolus.documents.provider;
 
 import android.database.AbstractCursor;
 

--- a/app/src/main/java/exe/bbllw8/aeolus/documents/provider/FileSystemProvider.java
+++ b/app/src/main/java/exe/bbllw8/aeolus/documents/provider/FileSystemProvider.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2022 2bllw8
  * SPDX-License-Identifier: GPL-3.0-only
  */
-package exe.bbllw8.anemo.documents.provider;
+package exe.bbllw8.aeolus.documents.provider;
 
 import android.annotation.SuppressLint;
 import android.content.ContentResolver;

--- a/app/src/main/java/exe/bbllw8/aeolus/documents/provider/PathUtils.java
+++ b/app/src/main/java/exe/bbllw8/aeolus/documents/provider/PathUtils.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2022 2bllw8
  * SPDX-License-Identifier: GPL-3.0-only
  */
-package exe.bbllw8.anemo.documents.provider;
+package exe.bbllw8.aeolus.documents.provider;
 
 import android.provider.DocumentsContract;
 import android.text.TextUtils;

--- a/app/src/main/java/exe/bbllw8/aeolus/documents/receiver/ReceiverActivity.java
+++ b/app/src/main/java/exe/bbllw8/aeolus/documents/receiver/ReceiverActivity.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2022 2bllw8
  * SPDX-License-Identifier: GPL-3.0-only
  */
-package exe.bbllw8.anemo.documents.receiver;
+package exe.bbllw8.aeolus.documents.receiver;
 
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -23,9 +23,9 @@ import java.io.OutputStream;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
-import exe.bbllw8.anemo.R;
-import exe.bbllw8.anemo.documents.home.HomeEnvironment;
-import exe.bbllw8.anemo.task.TaskExecutor;
+import exe.bbllw8.aeolus.R;
+import exe.bbllw8.aeolus.documents.home.HomeEnvironment;
+import exe.bbllw8.aeolus.task.TaskExecutor;
 import exe.bbllw8.either.Try;
 
 public class ReceiverActivity extends Activity {

--- a/app/src/main/java/exe/bbllw8/aeolus/lock/AutoLockJobService.java
+++ b/app/src/main/java/exe/bbllw8/aeolus/lock/AutoLockJobService.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2021 2bllw8
  * SPDX-License-Identifier: GPL-3.0-only
  */
-package exe.bbllw8.anemo.lock;
+package exe.bbllw8.aeolus.lock;
 
 import android.app.job.JobParameters;
 import android.app.job.JobService;
@@ -10,7 +10,7 @@ import android.widget.Toast;
 
 import androidx.annotation.Nullable;
 
-import exe.bbllw8.anemo.R;
+import exe.bbllw8.aeolus.R;
 
 public final class AutoLockJobService extends JobService {
 

--- a/app/src/main/java/exe/bbllw8/aeolus/lock/LockStore.java
+++ b/app/src/main/java/exe/bbllw8/aeolus/lock/LockStore.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2021 2bllw8
  * SPDX-License-Identifier: GPL-3.0-only
  */
-package exe.bbllw8.anemo.lock;
+package exe.bbllw8.aeolus.lock;
 
 import android.app.job.JobInfo;
 import android.app.job.JobScheduler;

--- a/app/src/main/java/exe/bbllw8/aeolus/lock/LockTileService.java
+++ b/app/src/main/java/exe/bbllw8/aeolus/lock/LockTileService.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2021 2bllw8
  * SPDX-License-Identifier: GPL-3.0-only
  */
-package exe.bbllw8.anemo.lock;
+package exe.bbllw8.aeolus.lock;
 
 import android.content.ComponentName;
 import android.content.Intent;
@@ -15,7 +15,7 @@ import android.service.quicksettings.TileService;
 
 import java.util.function.Consumer;
 
-import exe.bbllw8.anemo.R;
+import exe.bbllw8.aeolus.R;
 
 public final class LockTileService extends TileService {
     private boolean hasUnlockActivity;

--- a/app/src/main/java/exe/bbllw8/aeolus/lock/UnlockActivity.java
+++ b/app/src/main/java/exe/bbllw8/aeolus/lock/UnlockActivity.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2022 2bllw8
  * SPDX-License-Identifier: GPL-3.0-only
  */
-package exe.bbllw8.anemo.lock;
+package exe.bbllw8.aeolus.lock;
 
 import android.app.Activity;
 import android.content.Intent;
@@ -18,10 +18,10 @@ import androidx.annotation.RequiresApi;
 
 import java.util.concurrent.Executor;
 
-import exe.bbllw8.anemo.R;
-import exe.bbllw8.anemo.config.ConfigurationActivity;
-import exe.bbllw8.anemo.config.password.TextListener;
-import exe.bbllw8.anemo.shell.LauncherActivity;
+import exe.bbllw8.aeolus.R;
+import exe.bbllw8.aeolus.config.ConfigurationActivity;
+import exe.bbllw8.aeolus.config.password.TextListener;
+import exe.bbllw8.aeolus.shell.LauncherActivity;
 
 public final class UnlockActivity extends Activity {
     public static final String OPEN_AFTER_UNLOCK = "open_after_unlock";

--- a/app/src/main/java/exe/bbllw8/aeolus/shell/AnemoShell.java
+++ b/app/src/main/java/exe/bbllw8/aeolus/shell/AnemoShell.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2022 2bllw8
  * SPDX-License-Identifier: GPL-3.0-only
  */
-package exe.bbllw8.anemo.shell;
+package exe.bbllw8.aeolus.shell;
 
 import android.content.ComponentName;
 import android.content.Context;

--- a/app/src/main/java/exe/bbllw8/aeolus/shell/LauncherActivity.java
+++ b/app/src/main/java/exe/bbllw8/aeolus/shell/LauncherActivity.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2022 2bllw8
  * SPDX-License-Identifier: GPL-3.0-only
  */
-package exe.bbllw8.anemo.shell;
+package exe.bbllw8.aeolus.shell;
 
 import android.app.Activity;
 import android.content.Intent;
@@ -17,10 +17,10 @@ import androidx.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Optional;
 
-import exe.bbllw8.anemo.R;
-import exe.bbllw8.anemo.documents.home.HomeEnvironment;
-import exe.bbllw8.anemo.lock.LockStore;
-import exe.bbllw8.anemo.lock.UnlockActivity;
+import exe.bbllw8.aeolus.R;
+import exe.bbllw8.aeolus.documents.home.HomeEnvironment;
+import exe.bbllw8.aeolus.lock.LockStore;
+import exe.bbllw8.aeolus.lock.UnlockActivity;
 
 public class LauncherActivity extends Activity {
     // https://cs.android.com/android/platform/superproject/+/master:packages/apps/DocumentsUI/AndroidManifest.xml

--- a/app/src/main/java/exe/bbllw8/aeolus/task/TaskExecutor.java
+++ b/app/src/main/java/exe/bbllw8/aeolus/task/TaskExecutor.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2021 2bllw8
  * SPDX-License-Identifier: GPL-3.0-only
  */
-package exe.bbllw8.anemo.task;
+package exe.bbllw8.aeolus.task;
 
 import android.os.Handler;
 import android.os.Looper;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,12 +3,12 @@
   ~ SPDX-License-Identifier: GPL-3.0-only
   -->
 <resources>
-    <string name="app_name">Anemo</string>
+    <string name="app_name">Aeolus</string>
 
     <string name="anemo_description">Local private storage</string>
     <string name="anemo_info">Files stored in the Anemo storage are private and other apps can\'t access them without the user\'s consent.</string>
 
-    <string name="password_label">Anemo password</string>
+    <string name="password_label">Aeolus password</string>
 
     <string name="password_hint_field">Password</string>
     <string name="password_hint_repeat">Type again to confirm</string>
@@ -32,22 +32,22 @@
     <string name="password_change_action">Change</string>
     <string name="password_change_remove">Remove</string>
 
-    <string name="receiver_label">Import into Anemo</string>
+    <string name="receiver_label">Import into Aeolus</string>
 
     <string name="receiver_importing_message">Importing the file…</string>
-    <string name="receiver_importing_done_ok">Imported to Anemo</string>
+    <string name="receiver_importing_done_ok">Imported to Aeolus</string>
     <string name="receiver_importing_done_fail">Could not import the file. Try again</string>
 
     <string name="receiver_default_file_name">Shared file</string>
 
-    <string name="tile_title">Anemo storage</string>
+    <string name="tile_title">Aeolus storage</string>
 
-    <string name="tile_lock">Lock Anemo</string>
-    <string name="tile_unlock">Unlock Anemo</string>
+    <string name="tile_lock">Lock Aeolus</string>
+    <string name="tile_unlock">Unlock Aeolus</string>
     <string name="tile_status_locked">Now locked</string>
     <string name="tile_status_unlocked">Now unlocked</string>
 
-    <string name="tile_auto_lock">Anemo storage was automatically locked</string>
+    <string name="tile_auto_lock">Aeolus storage was automatically locked</string>
 
     <string name="launcher_no_activity">Can\'t find system Files app</string>
     <string name="shortcut_config_long">Configuration</string>

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -13,7 +13,7 @@
 
         <intent
             android:action="android.intent.action.VIEW"
-            android:targetClass="exe.bbllw8.anemo.config.ConfigurationActivity"
-            android:targetPackage="exe.bbllw8.anemo" />
+            android:targetClass="exe.bbllw8.aeolus.config.ConfigurationActivity"
+            android:targetPackage="exe.bbllw8.aeolus" />
     </shortcut>
 </shortcuts>


### PR DESCRIPTION
This POC makes Anemo use external storage (memory card) to store files. Files are still private. 

A limitation of this POC (but not the method) is that it uses only external storage (since I just replace the "baseDir" definition)
I've changed the pkgid to build and install locally without replacing main app.

It'd be cool if you'd [have a look] and integrate this functionality directly in the main app. 
Giving user option to select either (internal/external), or use both (2 providers) at a time.

[have a look]: https://github.com/2bllw8/anemo/commit/638ef05c1050c948dc2498f28cfe34661c0e1b62

relates to #48 