### PR TITLE
README.md add link to translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,13 @@ Open an discussion [on github](https://github.com/2bllw8/anemo/discussions/new?c
 
 **Every contributions, including ideas, feature requests, bug reports and Pull Requests are welcome!**
 
-- **Solve bug(s)**, add **feature(s)** or **translate** Anemo to your native language by making a **[pull request](https://help.github.com/articles/about-pull-requests/)**
+**Translate** Anemo to your native language using the [Weblate](https://toolate.othing.xyz/projects/anemo).
+
+<a href="https://toolate.othing.xyz/projects/anemo">
+<img src="https://toolate.othing.xyz/widget/anemo/multi-auto.svg" alt="Translation status" />
+</a>
+
+- **Solve bug(s)**, add **feature(s)** by making a **[pull request](https://help.github.com/articles/about-pull-requests/)**
 - You have an idea for improvement or a new feature? Open a **[feature request](https://github.com/2bllw8/anemo/issues/new?assignees=&labels=enhancement&template=feature_request.yml&title=[Feature+request]+)**
 - You faced a bug, let us know by opening a **[bug report](https://github.com/2bllw8/anemo/issues/new?assignees=&labels=bug&template=bug_report.yml&title=%5BBug%5D+)**
 


### PR DESCRIPTION
Closes: #43

To make it easier to translate it would be great to integrate a translation service.
The https://toolate.othing.xyz/ is an instance of the [Weblate](https://weblate.org/), it has no pre-moderation, it can send a PR with translations, it has automatic translations from Baidu. It's used by many of the F-Droid apps.

I created a translation project on the Toolate https://toolate.othing.xyz/projects/anemo
and also made a testing translations and it sent you a PR #72.

If you are fine with the solution then please merge the PR that adds the Toolate link to the README to help users to find it. Also if you wish I can send you an invitation to become an admin of the translation project (needed sometimes to resolve merge conflicts).

Thank you for the app!
